### PR TITLE
Removes incorrect row div from dashboard home view

### DIFF
--- a/app/views/dashboard/home.html
+++ b/app/views/dashboard/home.html
@@ -29,23 +29,21 @@
             <!-- /.panel -->
         </div>
         <!-- /.col-lg-8 -->
-        <div class= "row">
-            <div class="col-lg-4">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <i class="fa fa-bell fa-fw"></i> Notifications Panel
-                    </div>
-                    <!-- /.panel-heading -->
-                    <notifications></notifications> 
-                    <!-- /.panel-body -->
+        <div class="col-lg-4">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <i class="fa fa-bell fa-fw"></i> Notifications Panel
                 </div>
-                <!-- /.panel -->
-
-                <chat></chat>
-                 <!-- /.panel .chat-panel -->
+                <!-- /.panel-heading -->
+                <notifications></notifications> 
+                <!-- /.panel-body -->
             </div>
-            <!-- /.col-lg-4 -->
+            <!-- /.panel -->
+
+            <chat></chat>
+             <!-- /.panel .chat-panel -->
         </div>
-        <!-- /.row -->
+        <!-- /.col-lg-4 -->
     </div>
+    <!-- /.row -->
 </div>


### PR DESCRIPTION
The layout of the `Notifications Panel` and `Chat` panel on the dashboard page gets broken when resizing the window to a small size.
